### PR TITLE
Capturing coverage for observing the instruction pattern of alu, mul/div & floating-point.

### DIFF
--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1797,11 +1797,20 @@ module ibex_decoder #(
     ALU_OPERATIONS: coverpoint alu_operator_o;
   endgroup : alu_cg
 
-  alu_cg alu_cg_h;
+  // Covergroup to capture Multiplier/divider operations
+  covergroup mul_div_cg ()@(multdiv_operator_o); 
+    MUL_DIV_OPERATIONS: coverpoint multdiv_operator_o;
+  endgroup : mul_div_cg
+
+  alu_cg     alu_cg_h    ;
+  mul_div_cg mul_div_cg_h;
 
   initial begin
-    alu_cg_h     = new();     // Creating an instance of a covergroup
+    alu_cg_h     = new();     // Instance of a alu covergroup
+    mul_div_cg_h = new();     // Instance of a mul/div covergroup
+    
     //alu_cg_h.set_inst_name("ALU OPERATIONS COVERAGES");
+    //mul_div_cg_h.set_inst_name("MUL/DIV OPERATIONS COVERAGES");
   end
 
 endmodule // controller

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1802,12 +1802,19 @@ module ibex_decoder #(
     MUL_DIV_OPERATIONS: coverpoint multdiv_operator_o;
   endgroup : mul_div_cg
 
+  // Covergroup to capture floating point operations
+  covergroup fpu_cg ()@(fp_alu_operator_o); 
+    FPU_OPERATIONS: coverpoint fp_alu_operator_o;
+  endgroup : fpu_cg
+
   alu_cg     alu_cg_h    ;
   mul_div_cg mul_div_cg_h;
+  fpu_cg     fpu_cg_h    ;
 
   initial begin
     alu_cg_h     = new();     // Instance of a alu covergroup
     mul_div_cg_h = new();     // Instance of a mul/div covergroup
+    fpu_cg_h     = new();     // Instance of a fpu covergroup
     
     //alu_cg_h.set_inst_name("ALU OPERATIONS COVERAGES");
     //mul_div_cg_h.set_inst_name("MUL/DIV OPERATIONS COVERAGES");

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1791,7 +1791,8 @@ module ibex_decoder #(
   ////////////////////////
   //Functional coverages//
   ////////////////////////
-
+  
+  `ifdef AZADI_FC
   // Covergroup to capture ALU operations 
   covergroup alu_cg ()@(alu_operator_o); 
     ALU_OPERATIONS: coverpoint alu_operator_o;
@@ -1814,11 +1815,12 @@ module ibex_decoder #(
   initial begin
     alu_cg_h     = new();     // Instance of a alu covergroup
     mul_div_cg_h = new();     // Instance of a mul/div covergroup
-    fpu_cg_h     = new();     // Instance of a fpu covergroup
-    
+    fpu_cg_h     = new();     // Instance of a fpu covergroup  
     //alu_cg_h.set_inst_name("ALU OPERATIONS COVERAGES");
     //mul_div_cg_h.set_inst_name("MUL/DIV OPERATIONS COVERAGES");
   end
+  
+  `endif  // AZADI_FC
 
 endmodule // controller
 

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1787,4 +1787,22 @@ module ibex_decoder #(
   // Selectors must be known/valid.
   `ASSERT(IbexRegImmAluOpKnown, (opcode == OPCODE_OP_IMM) |->
       !$isunknown(instr[14:12]))
+
+  ////////////////////////
+  //Functional coverages//
+  ////////////////////////
+
+  // Covergroup to capture ALU operations 
+  covergroup alu_cg ()@(alu_operator_o); 
+    ALU_OPERATIONS: coverpoint alu_operator_o;
+  endgroup : alu_cg
+
+  alu_cg alu_cg_h;
+
+  initial begin
+    alu_cg_h     = new();     // Creating an instance of a covergroup
+    //alu_cg_h.set_inst_name("ALU OPERATIONS COVERAGES");
+  end
+
 endmodule // controller
+


### PR DESCRIPTION
- Added cover-groups to capture the functional coverage for `ALU`, `MUL/DIV` & `floating-point` operations.
- Incorporated `ifdef` condition for same `cover-groups`.