### PR TITLE
Incorporated functional coverage of Azadi core

### DIFF
--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1799,7 +1799,7 @@ module ibex_decoder #(
       ignore_bins ignore_vals = {ALU_XNOR, ALU_ORN, ALU_ANDN, ALU_SRO, ALU_SLO, ALU_ROR, ALU_ROL, ALU_GREV, 
                                  ALU_GORC, ALU_SHFL, ALU_UNSHFL, ALU_MIN, ALU_MINU, ALU_MAX, ALU_MAXU, ALU_PACK,
                                  ALU_PACKU, ALU_PACKH, ALU_SEXTB, ALU_SEXTH, ALU_CLZ, ALU_CTZ, ALU_PCNT, ALU_CMOV,
-                                 ALU_CMIX, ALU_FSL, ALU_FSR};
+                                 ALU_CMIX, ALU_FSL, ALU_FSR, ALU_SBSET, ALU_SBCLR, ALU_SBINV, ALU_SBEXT};
     }
   endgroup : alu_cg
 

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1914,6 +1914,15 @@ module ibex_decoder #(
   covergroup alu_op_b_mux_sel_cg()@(alu_op_b_mux_sel_o);
     ALU_OPERAND_B_MUX_SEL: coverpoint alu_op_b_mux_sel_o;
   endgroup : alu_op_b_mux_sel_cg
+
+  /////////////////////////////////////
+  // Covergroup for bit-manipulation //
+  /////////////////////////////////////
+
+  covergroup bit_manipulation_cg()@(RV32B);
+    BIT_MANIPULATION: coverpoint RV32B;
+  endgroup : bit_manipulation_cg
+
   
   // Declaration of cover-groups
   alu_cg               alu_cg_h              ;
@@ -1926,6 +1935,7 @@ module ibex_decoder #(
   alu_op_a_mux_sel_cg  alu_op_a_mux_sel_cg_h ;
   alu_op_b_mux_sel_cg  alu_op_b_mux_sel_cg_h ;
   imm_operand_b_sel_cg imm_operand_b_sel_cg_h;
+  bit_manipulation_cg  bit_manipulation_cg_h ;
 
   initial begin
     alu_cg_h               = new();     // Instance of a alu covergroup
@@ -1938,6 +1948,7 @@ module ibex_decoder #(
     alu_op_a_mux_sel_cg_h  = new();     // Instance of a alu_op_a_mux_sel_o covergroup
     alu_op_b_mux_sel_cg_h  = new();     // Instance of a alu_op_b_mux_sel_o covergroup
     imm_operand_b_sel_cg_h = new();     // Instance of a imm_b_mux_sel_o covergroup
+    bit_manipulation_cg_h  = new();     // Instance of a RV32B covergroup
   end
 
   `endif  // AZADI_FC

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1798,7 +1798,7 @@ module ibex_decoder #(
     ALU_OPERATIONS: coverpoint alu_operator_o{
       ignore_bins ignore_vals = {ALU_XNOR, ALU_ORN, ALU_ANDN, ALU_SRO, ALU_SLO, ALU_ROR, ALU_ROL, ALU_GREV, 
                                  ALU_GORC, ALU_SHFL, ALU_UNSHFL, ALU_MIN, ALU_MINU, ALU_MAX, ALU_MAXU, ALU_PACK,
-                                 ALU_PACKU, ALU_PACKH};
+                                 ALU_PACKU, ALU_PACKH, ALU_SEXTB, ALU_SEXTH, ALU_CLZ, ALU_CTZ, ALU_PCNT};
     }
   endgroup : alu_cg
 

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1889,6 +1889,17 @@ module ibex_decoder #(
     BT_OPERAND_B_SEL: coverpoint bt_b_mux_sel_o;
   endgroup : bt_operand_b_sel_cg
 
+  ////////////////////////////////////////////////////////////////
+  // Covergroup for branch-target-ALU operand "A" mux selection //
+  ////////////////////////////////////////////////////////////////
+  
+  // OP_A_REG_A (operand A from register)
+  // OP_A_FWD   (operand A from forward )
+  // OP_A_CURRPC(operand A as current pc)
+  // OP_A_IMM   (operand A as immediate )
+  covergroup alu_op_a_mux_sel_cg()@(alu_op_a_mux_sel_o);
+    ALU_OPERAND_A_MUX_SEL: coverpoint alu_op_a_mux_sel_o;
+  endgroup : alu_op_a_mux_sel_cg
   
   // Declaration of cover-groups
   alu_cg        alu_cg_h       ;
@@ -1898,6 +1909,7 @@ module ibex_decoder #(
   opcode_alu_cg opcode_alu_cg_h;
   bt_operand_a_sel_cg bt_operand_a_sel_cg_h;
   bt_operand_b_sel_cg bt_operand_b_sel_cg_h;
+  alu_op_a_mux_sel_cg alu_op_a_mux_sel_cg_h;
 
   initial begin
     alu_cg_h              = new();     // Instance of a alu covergroup
@@ -1907,6 +1919,7 @@ module ibex_decoder #(
     opcode_alu_cg_h       = new();     // Instance of a opcode_alu covergroup
     bt_operand_a_sel_cg_h = new();     // Instance of a bt_a_mux_sel_o covergroup
     bt_operand_b_sel_cg_h = new();     // Instance of a bt_b_mux_sel_o covergroup
+    alu_op_a_mux_sel_cg_h = new();     // Instance of a alu_op_a_mux_sel_o covergroup
   end
 
   `endif  // AZADI_FC

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1794,8 +1794,10 @@ module ibex_decoder #(
   
   `ifdef AZADI_FC
   // Covergroup to capture ALU operations 
-  covergroup alu_cg ()@(alu_operator_o); 
-    ALU_OPERATIONS: coverpoint alu_operator_o;
+      covergroup alu_cg ()@(alu_operator_o); 
+    ALU_OPERATIONS: coverpoint alu_operator_o{
+      ignore_bins ignore_vals = {ALU_XNOR, ALU_ORN, ALU_ANDN, ALU_SRO, ALU_SLO, ALU_ROR, ALU_ROL, ALU_GREV, ALU_GORC, ALU_SHFL, ALU_UNSHFL};
+    }
   endgroup : alu_cg
 
   // Covergroup to capture Multiplier/divider operations

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1799,7 +1799,8 @@ module ibex_decoder #(
       ignore_bins ignore_vals = {ALU_XNOR, ALU_ORN, ALU_ANDN, ALU_SRO, ALU_SLO, ALU_ROR, ALU_ROL, ALU_GREV, 
                                  ALU_GORC, ALU_SHFL, ALU_UNSHFL, ALU_MIN, ALU_MINU, ALU_MAX, ALU_MAXU, ALU_PACK,
                                  ALU_PACKU, ALU_PACKH, ALU_SEXTB, ALU_SEXTH, ALU_CLZ, ALU_CTZ, ALU_PCNT, ALU_CMOV,
-                                 ALU_CMIX, ALU_FSL, ALU_FSR, ALU_SBSET, ALU_SBCLR, ALU_SBINV, ALU_SBEXT};
+                                 ALU_CMIX, ALU_FSL, ALU_FSR, ALU_SBSET, ALU_SBCLR, ALU_SBINV, ALU_SBEXT, ALU_BEXT,
+                                 ALU_BDEP};
     }
   endgroup : alu_cg
 

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1935,11 +1935,11 @@ module ibex_decoder #(
   /////////////////////////////////////
   // Covergroup for bit-manipulation //
   /////////////////////////////////////
-
-  covergroup bit_manipulation_cg()@(RV32B);
-    BIT_MANIPULATION: coverpoint RV32B;
-  endgroup : bit_manipulation_cg
-
+  `ifdef BIT_MANIPULATION_ENABLED
+    covergroup bit_manipulation_cg()@(RV32B);
+      BIT_MANIPULATION: coverpoint RV32B;
+    endgroup : bit_manipulation_cg
+  `endif  // BIT_MANIPULATION_ENABLED
   
   // Declaration of cover-groups
   alu_cg               alu_cg_h              ;
@@ -1956,24 +1956,30 @@ module ibex_decoder #(
   alu_op_a_mux_sel_cg  alu_op_a_mux_sel_cg_h ;
   alu_op_b_mux_sel_cg  alu_op_b_mux_sel_cg_h ;
   imm_operand_b_sel_cg imm_operand_b_sel_cg_h;
-  bit_manipulation_cg  bit_manipulation_cg_h ;
+
+  `ifdef BIT_MANIPULATION_ENABLED
+    bit_manipulation_cg  bit_manipulation_cg_h ;
+  `endif  // BIT_MANIPULATION_ENABLED
 
   initial begin
-    alu_cg_h               = new();     // Instance of a alu covergroup
-    mul_div_cg_h           = new();     // Instance of a mul/div covergroup
-    fpu_cg_h               = new();     // Instance of a fpu covergroup
-    opcode_cg_h            = new();     // Instance of a opcode covergroup
-    opcode_alu_cg_h        = new();     // Instance of a opcode_alu covergroup
+    alu_cg_h               = new();       // Instance of a alu covergroup
+    mul_div_cg_h           = new();       // Instance of a mul/div covergroup
+    fpu_cg_h               = new();       // Instance of a fpu covergroup
+    opcode_cg_h            = new();       // Instance of a opcode covergroup
+    opcode_alu_cg_h        = new();       // Instance of a opcode_alu covergroup
     
     `ifdef BRANCH_TARGET_ALU_ENABLED
       bt_operand_a_sel_cg_h  = new();     // Instance of a bt_a_mux_sel_o covergroup
       bt_operand_b_sel_cg_h  = new();     // Instance of a bt_b_mux_sel_o covergroup
     `endif  // BRANCH_TARGET_ALU_ENABLED
     
-    alu_op_a_mux_sel_cg_h  = new();     // Instance of a alu_op_a_mux_sel_o covergroup
-    alu_op_b_mux_sel_cg_h  = new();     // Instance of a alu_op_b_mux_sel_o covergroup
-    imm_operand_b_sel_cg_h = new();     // Instance of a imm_b_mux_sel_o covergroup
-    bit_manipulation_cg_h  = new();     // Instance of a RV32B covergroup
+    alu_op_a_mux_sel_cg_h  = new();       // Instance of a alu_op_a_mux_sel_o covergroup
+    alu_op_b_mux_sel_cg_h  = new();       // Instance of a alu_op_b_mux_sel_o covergroup
+    imm_operand_b_sel_cg_h = new();       // Instance of a imm_b_mux_sel_o covergroup
+    
+    `ifdef BIT_MANIPULATION_ENABLED
+      bit_manipulation_cg_h  = new();     // Instance of a RV32B covergroup
+    `endif  // BIT_MANIPULATION_ENABLED
   end
 
   `endif  // AZADI_FC

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1800,7 +1800,8 @@ module ibex_decoder #(
                                  ALU_GORC, ALU_SHFL, ALU_UNSHFL, ALU_MIN, ALU_MINU, ALU_MAX, ALU_MAXU, ALU_PACK,
                                  ALU_PACKU, ALU_PACKH, ALU_SEXTB, ALU_SEXTH, ALU_CLZ, ALU_CTZ, ALU_PCNT, ALU_CMOV,
                                  ALU_CMIX, ALU_FSL, ALU_FSR, ALU_SBSET, ALU_SBCLR, ALU_SBINV, ALU_SBEXT, ALU_BEXT,
-                                 ALU_BDEP, ALU_BFP, ALU_CLMUL, ALU_CLMULR, ALU_CLMULH};
+                                 ALU_BDEP, ALU_BFP, ALU_CLMUL, ALU_CLMULR, ALU_CLMULH, ALU_CRC32_B, ALU_CRC32C_B, 
+                                 ALU_CRC32_H, ALU_CRC32C_H, ALU_CRC32_W, ALU_CRC32C_W};
     }
   endgroup : alu_cg
 

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1807,20 +1807,47 @@ module ibex_decoder #(
   covergroup fpu_cg ()@(fp_alu_operator_o); 
     FPU_OPERATIONS: coverpoint fp_alu_operator_o;
   endgroup : fpu_cg
-
+  
+  ////////////////////////////////////////////////////////////////////////////////////
+  // Added cover-group to capture coverage for opcode type def present in ibex_pkg  //
+  ////////////////////////////////////////////////////////////////////////////////////
+  // OPCODE_JAL (Jump and Link)
+  // OPCODE_JALR (Jump and Link Register)
+  // OPCODE_BRANCH (Branch)
+  // OPCODE_STORE (Store)
+  // OPCODE_LOAD (Load)
+  // OPCODE_LUI (Load Upper Immediate)
+  // OPCODE_AUIPC (Add Upper Immediate to PC)
+  // OPCODE_OP_IMM (Register-Immediate ALU Operations)
+  // OPCODE_OP (Register-Register ALU operation)
+  // OPCODE_MISC_MEM ( Special)
+  // OPCODE_SYSTEM   (Special)
+  // Floating point 
+  // OPCODE_STORE_FP (Store fp)
+  // OPCODE_LOAD_FP (Load fp)
+  // OPCODE_MADD_FP,  // FMADD.S, FMADD.D
+  // OPCODE_MSUB_FP,  // FMSUB.S, FMSUB.D
+  // OPCODE_NMSUB_FP, // FNMSUB.S, FNMSUB.//D
+  // OPCODE_NMADD_FP: begin //FNMADD.S, FN//MAD
+  // OPCODE_OP_FP
+  // OPCODE_OP_FP
+  covergroup opcode_cg()@(opcode);
+    OPCODE_OPERATIONS: coverpoint opcode;
+  endgroup : opcode_cg
+  
+  // Declaration of cover-groups
   alu_cg     alu_cg_h    ;
   mul_div_cg mul_div_cg_h;
   fpu_cg     fpu_cg_h    ;
+  opcode_cg  opcode_cg_h ;
 
   initial begin
     alu_cg_h     = new();     // Instance of a alu covergroup
     mul_div_cg_h = new();     // Instance of a mul/div covergroup
     fpu_cg_h     = new();     // Instance of a fpu covergroup  
-    //alu_cg_h.set_inst_name("ALU OPERATIONS COVERAGES");
-    //mul_div_cg_h.set_inst_name("MUL/DIV OPERATIONS COVERAGES");
+    opcode_cg_h  = new();     // Instance of a opcode covergroup
   end
   
   `endif  // AZADI_FC
 
 endmodule // controller
-

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1797,7 +1797,8 @@ module ibex_decoder #(
       covergroup alu_cg ()@(alu_operator_o); 
     ALU_OPERATIONS: coverpoint alu_operator_o{
       ignore_bins ignore_vals = {ALU_XNOR, ALU_ORN, ALU_ANDN, ALU_SRO, ALU_SLO, ALU_ROR, ALU_ROL, ALU_GREV, 
-                                 ALU_GORC, ALU_SHFL, ALU_UNSHFL, ALU_MIN, ALU_MINU, ALU_MAX, ALU_MAXU};
+                                 ALU_GORC, ALU_SHFL, ALU_UNSHFL, ALU_MIN, ALU_MINU, ALU_MAX, ALU_MAXU, ALU_PACK,
+                                 ALU_PACKU, ALU_PACKH};
     }
   endgroup : alu_cg
 

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1862,9 +1862,9 @@ module ibex_decoder #(
     OPCODE_ALU_OPERATIONS: coverpoint opcode_alu;
   endgroup : opcode_alu_cg
 
-  /////////////////////////////////////////
-  // Branch target Operand "A" selection //
-  /////////////////////////////////////////
+  ////////////////////////////////////////////////////////
+  // Covergroup for branch target operand "A" selection //
+  ////////////////////////////////////////////////////////
   
   // OP_A_REG_A (operand A from register)
   // OP_A_FWD   (operand A from forward )
@@ -1873,6 +1873,22 @@ module ibex_decoder #(
   covergroup bt_operand_a_sel_cg()@(bt_a_mux_sel_o);
     BT_OPERAND_A_SEL: coverpoint bt_a_mux_sel_o;
   endgroup : bt_operand_a_sel_cg
+
+  //////////////////////////////////////////////////////////
+  // Covergroup for branch target immediate "B" selection //
+  //////////////////////////////////////////////////////////
+  
+  // IMM_B_I,        (Immediate b)
+  // IMM_B_S,        (Immediate b for store)
+  // IMM_B_B,        (Immediate b for branch)
+  // IMM_B_U,        (Immediate b for LUI and AUPIC)
+  // IMM_B_J,        (Immediate b for jump)
+  // IMM_B_INCR_PC,  (Immediate b for PC increment)
+  // IMM_B_INCR_ADDR (immediate b for adder)
+
+  covergroup bt_operand_b_sel_cg()@(bt_b_mux_sel_o);
+    BT_OPERAND_B_SEL: coverpoint bt_b_mux_sel_o;
+  endgroup : bt_operand_b_sel_cg
 
   
   // Declaration of cover-groups

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1889,9 +1889,9 @@ module ibex_decoder #(
     BT_OPERAND_B_SEL: coverpoint bt_b_mux_sel_o;
   endgroup : bt_operand_b_sel_cg
 
-  ////////////////////////////////////////////////////////////////
-  // Covergroup for branch-target-ALU operand "A" mux selection //
-  ////////////////////////////////////////////////////////////////
+  //////////////////////////////////////////////////
+  // Covergroup for ALU operand "A" mux selection //
+  //////////////////////////////////////////////////
   
   // OP_A_REG_A (operand A from register)
   // OP_A_FWD   (operand A from forward )
@@ -1900,16 +1900,27 @@ module ibex_decoder #(
   covergroup alu_op_a_mux_sel_cg()@(alu_op_a_mux_sel_o);
     ALU_OPERAND_A_MUX_SEL: coverpoint alu_op_a_mux_sel_o;
   endgroup : alu_op_a_mux_sel_cg
+
+  //////////////////////////////////////////////////
+  // Covergroup for ALU operand "B" mux selection //
+  //////////////////////////////////////////////////
+  
+  // OP_B_REG_B (Operand b from register file)
+  // OP_B_IMM   (Operand b as immediate value)
+  covergroup alu_op_b_mux_sel_cg()@(alu_op_b_mux_sel_o);
+    ALU_OPERAND_B_MUX_SEL: coverpoint alu_op_b_mux_sel_o;
+  endgroup : alu_op_b_mux_sel_cg
   
   // Declaration of cover-groups
-  alu_cg        alu_cg_h       ;
-  mul_div_cg    mul_div_cg_h   ;
-  fpu_cg        fpu_cg_h       ;
-  opcode_cg     opcode_cg_h    ;
-  opcode_alu_cg opcode_alu_cg_h;
+  alu_cg              alu_cg_h             ;
+  mul_div_cg          mul_div_cg_h         ;
+  fpu_cg              fpu_cg_h             ;
+  opcode_cg           opcode_cg_h          ;
+  opcode_alu_cg       opcode_alu_cg_h      ;
   bt_operand_a_sel_cg bt_operand_a_sel_cg_h;
   bt_operand_b_sel_cg bt_operand_b_sel_cg_h;
   alu_op_a_mux_sel_cg alu_op_a_mux_sel_cg_h;
+  alu_op_b_mux_sel_cg alu_op_b_mux_sel_cg_h;
 
   initial begin
     alu_cg_h              = new();     // Instance of a alu covergroup
@@ -1920,6 +1931,7 @@ module ibex_decoder #(
     bt_operand_a_sel_cg_h = new();     // Instance of a bt_a_mux_sel_o covergroup
     bt_operand_b_sel_cg_h = new();     // Instance of a bt_b_mux_sel_o covergroup
     alu_op_a_mux_sel_cg_h = new();     // Instance of a alu_op_a_mux_sel_o covergroup
+    alu_op_b_mux_sel_cg_h = new();     // Instance of a alu_op_b_mux_sel_o covergroup
   end
 
   `endif  // AZADI_FC

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1798,7 +1798,8 @@ module ibex_decoder #(
     ALU_OPERATIONS: coverpoint alu_operator_o{
       ignore_bins ignore_vals = {ALU_XNOR, ALU_ORN, ALU_ANDN, ALU_SRO, ALU_SLO, ALU_ROR, ALU_ROL, ALU_GREV, 
                                  ALU_GORC, ALU_SHFL, ALU_UNSHFL, ALU_MIN, ALU_MINU, ALU_MAX, ALU_MAXU, ALU_PACK,
-                                 ALU_PACKU, ALU_PACKH, ALU_SEXTB, ALU_SEXTH, ALU_CLZ, ALU_CTZ, ALU_PCNT};
+                                 ALU_PACKU, ALU_PACKH, ALU_SEXTB, ALU_SEXTH, ALU_CLZ, ALU_CTZ, ALU_PCNT, ALU_CMOV,
+                                 ALU_CMIX, ALU_FSL, ALU_FSR};
     }
   endgroup : alu_cg
 

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1800,7 +1800,7 @@ module ibex_decoder #(
                                  ALU_GORC, ALU_SHFL, ALU_UNSHFL, ALU_MIN, ALU_MINU, ALU_MAX, ALU_MAXU, ALU_PACK,
                                  ALU_PACKU, ALU_PACKH, ALU_SEXTB, ALU_SEXTH, ALU_CLZ, ALU_CTZ, ALU_PCNT, ALU_CMOV,
                                  ALU_CMIX, ALU_FSL, ALU_FSR, ALU_SBSET, ALU_SBCLR, ALU_SBINV, ALU_SBEXT, ALU_BEXT,
-                                 ALU_BDEP};
+                                 ALU_BDEP, ALU_BFP, ALU_CLMUL, ALU_CLMULR, ALU_CLMULH};
     }
   endgroup : alu_cg
 

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1794,15 +1794,16 @@ module ibex_decoder #(
   
   `ifdef AZADI_FC
   // Covergroup to capture ALU operations 
-      covergroup alu_cg ()@(alu_operator_o); 
+  covergroup alu_cg ()@(alu_operator_o); 
     ALU_OPERATIONS: coverpoint alu_operator_o{
-      ignore_bins ignore_vals = {ALU_XNOR, ALU_ORN, ALU_ANDN, ALU_SRO, ALU_SLO, ALU_ROR, ALU_ROL, ALU_GREV, 
-                                 ALU_GORC, ALU_SHFL, ALU_UNSHFL, ALU_MIN, ALU_MINU, ALU_MAX, ALU_MAXU, ALU_PACK,
-                                 ALU_PACKU, ALU_PACKH, ALU_SEXTB, ALU_SEXTH, ALU_CLZ, ALU_CTZ, ALU_PCNT, ALU_CMOV,
-                                 ALU_CMIX, ALU_FSL, ALU_FSR, ALU_SBSET, ALU_SBCLR, ALU_SBINV, ALU_SBEXT, ALU_BEXT,
-                                 ALU_BDEP, ALU_BFP, ALU_CLMUL, ALU_CLMULR, ALU_CLMULH, ALU_CRC32_B, ALU_CRC32C_B, 
-                                 ALU_CRC32_H, ALU_CRC32C_H, ALU_CRC32_W, ALU_CRC32C_W};
-    }
+      // Ignore bins for bit manipulation extension
+      ignore_bins ignore_vals = {ALU_XNOR, ALU_ORN, ALU_ANDN, ALU_SRO, ALU_SLO, ALU_ROR, ALU_ROL, ALU_GREV,
+        ALU_GORC, ALU_SHFL, ALU_UNSHFL, ALU_MIN, ALU_MINU, ALU_MAX, ALU_MAXU, ALU_PACK,
+        ALU_PACKU, ALU_PACKH, ALU_SEXTB, ALU_SEXTH, ALU_CLZ, ALU_CTZ, ALU_PCNT, ALU_CMOV,
+        ALU_CMIX, ALU_FSL, ALU_FSR, ALU_SBSET, ALU_SBCLR, ALU_SBINV, ALU_SBEXT, ALU_BEXT,
+        ALU_BDEP, ALU_BFP, ALU_CLMUL, ALU_CLMULR, ALU_CLMULH, ALU_CRC32_B, ALU_CRC32C_B,
+        ALU_CRC32_H, ALU_CRC32C_H, ALU_CRC32_W, ALU_CRC32C_W};
+      }
   endgroup : alu_cg
 
   // Covergroup to capture Multiplier/divider operations
@@ -1812,7 +1813,11 @@ module ibex_decoder #(
 
   // Covergroup to capture floating point operations
   covergroup fpu_cg ()@(fp_alu_operator_o); 
-    FPU_OPERATIONS: coverpoint fp_alu_operator_o;
+    FPU_OPERATIONS: coverpoint fp_alu_operator_o {
+      // Ignore bins for floating to floating (double floating point not implemented)
+      // and CPKAB & CPKCD (out of risc-v specs for instruction generation do not generates these)
+      ignore_bins ignore_values = {F2F, CPKAB, CPKCD};
+      }
   endgroup : fpu_cg
   
   ////////////////////////////////////////////////////////////////////////////////////

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1796,7 +1796,8 @@ module ibex_decoder #(
   // Covergroup to capture ALU operations 
       covergroup alu_cg ()@(alu_operator_o); 
     ALU_OPERATIONS: coverpoint alu_operator_o{
-      ignore_bins ignore_vals = {ALU_XNOR, ALU_ORN, ALU_ANDN, ALU_SRO, ALU_SLO, ALU_ROR, ALU_ROL, ALU_GREV, ALU_GORC, ALU_SHFL, ALU_UNSHFL};
+      ignore_bins ignore_vals = {ALU_XNOR, ALU_ORN, ALU_ANDN, ALU_SRO, ALU_SLO, ALU_ROR, ALU_ROL, ALU_GREV, 
+                                 ALU_GORC, ALU_SHFL, ALU_UNSHFL, ALU_MIN, ALU_MINU, ALU_MAX, ALU_MAXU};
     }
   endgroup : alu_cg
 

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1797,13 +1797,15 @@ module ibex_decoder #(
   covergroup alu_cg ()@(alu_operator_o); 
     ALU_OPERATIONS: coverpoint alu_operator_o{
       // Ignore bins for bit manipulation extension
-      ignore_bins ignore_vals = {ALU_XNOR, ALU_ORN, ALU_ANDN, ALU_SRO, ALU_SLO, ALU_ROR, ALU_ROL, ALU_GREV,
-        ALU_GORC, ALU_SHFL, ALU_UNSHFL, ALU_MIN, ALU_MINU, ALU_MAX, ALU_MAXU, ALU_PACK,
-        ALU_PACKU, ALU_PACKH, ALU_SEXTB, ALU_SEXTH, ALU_CLZ, ALU_CTZ, ALU_PCNT, ALU_CMOV,
-        ALU_CMIX, ALU_FSL, ALU_FSR, ALU_SBSET, ALU_SBCLR, ALU_SBINV, ALU_SBEXT, ALU_BEXT,
-        ALU_BDEP, ALU_BFP, ALU_CLMUL, ALU_CLMULR, ALU_CLMULH, ALU_CRC32_B, ALU_CRC32C_B,
-        ALU_CRC32_H, ALU_CRC32C_H, ALU_CRC32_W, ALU_CRC32C_W};
+      `ifndef BIT_MANIPULATION_ENABLED
+        ignore_bins ignore_vals = {ALU_XNOR, ALU_ORN, ALU_ANDN, ALU_SRO, ALU_SLO, ALU_ROR, ALU_ROL, ALU_GREV,
+          ALU_GORC, ALU_SHFL, ALU_UNSHFL, ALU_MIN, ALU_MINU, ALU_MAX, ALU_MAXU, ALU_PACK,
+          ALU_PACKU, ALU_PACKH, ALU_SEXTB, ALU_SEXTH, ALU_CLZ, ALU_CTZ, ALU_PCNT, ALU_CMOV,
+          ALU_CMIX, ALU_FSL, ALU_FSR, ALU_SBSET, ALU_SBCLR, ALU_SBINV, ALU_SBEXT, ALU_BEXT,
+          ALU_BDEP, ALU_BFP, ALU_CLMUL, ALU_CLMULR, ALU_CLMULH, ALU_CRC32_B, ALU_CRC32C_B,
+          ALU_CRC32_H, ALU_CRC32C_H, ALU_CRC32_W, ALU_CRC32C_W};
       }
+      `endif
   endgroup : alu_cg
 
   // Covergroup to capture Multiplier/divider operations

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1813,11 +1813,11 @@ module ibex_decoder #(
 
   // Covergroup to capture floating point operations
   covergroup fpu_cg ()@(fp_alu_operator_o); 
-    FPU_OPERATIONS: coverpoint fp_alu_operator_o {
+    FPU_OPERATIONS: coverpoint fp_alu_operator_o{
       // Ignore bins for floating to floating (double floating point not implemented)
       // and CPKAB & CPKCD (out of risc-v specs for instruction generation do not generates these)
-      ignore_bins ignore_values = {F2F, CPKAB, CPKCD};
-      }
+      ignore_bins ignore_vals = {F2F, CPKAB, CPKCD};
+    }
   endgroup : fpu_cg
   
   ////////////////////////////////////////////////////////////////////////////////////
@@ -1882,9 +1882,12 @@ module ibex_decoder #(
   // OP_A_FWD   (operand A from forward )
   // OP_A_CURRPC(operand A as current pc)
   // OP_A_IMM   (operand A as immediate )
-  covergroup bt_operand_a_sel_cg()@(bt_a_mux_sel_o);
-    BT_OPERAND_A_SEL: coverpoint bt_a_mux_sel_o;
-  endgroup : bt_operand_a_sel_cg
+  `ifdef BRANCH_TARGET_ALU_ENABLED
+    covergroup bt_operand_a_sel_cg()@(bt_a_mux_sel_o);
+      BT_OPERAND_A_SEL: coverpoint bt_a_mux_sel_o;
+    endgroup : bt_operand_a_sel_cg
+  `endif  // BRANCH_TARGET_ALU_ENABLED
+
 
   //////////////////////////////////////////////////////////
   // Covergroup for branch target immediate "B" selection //
@@ -1897,9 +1900,11 @@ module ibex_decoder #(
   // IMM_B_J,        (Immediate b for jump)
   // IMM_B_INCR_PC,  (Immediate b for PC increment)
   // IMM_B_INCR_ADDR (immediate b for adder)
-  covergroup bt_operand_b_sel_cg()@(bt_b_mux_sel_o);
-    BT_OPERAND_B_SEL: coverpoint bt_b_mux_sel_o;
-  endgroup : bt_operand_b_sel_cg
+  `ifdef BRANCH_TARGET_ALU_ENABLED
+    covergroup bt_operand_b_sel_cg()@(bt_b_mux_sel_o);
+      BT_OPERAND_B_SEL: coverpoint bt_b_mux_sel_o;
+    endgroup : bt_operand_b_sel_cg
+  `endif  // BRANCH_TARGET_ALU_ENABLED
 
   covergroup imm_operand_b_sel_cg()@(imm_b_mux_sel_o);
     IMM_OPERAND_B_SEL: coverpoint imm_b_mux_sel_o;
@@ -1942,8 +1947,12 @@ module ibex_decoder #(
   fpu_cg               fpu_cg_h              ;
   opcode_cg            opcode_cg_h           ;
   opcode_alu_cg        opcode_alu_cg_h       ;
-  bt_operand_a_sel_cg  bt_operand_a_sel_cg_h ;
-  bt_operand_b_sel_cg  bt_operand_b_sel_cg_h ;
+  
+  `ifdef BRANCH_TARGET_ALU_ENABLED
+    bt_operand_a_sel_cg  bt_operand_a_sel_cg_h ;
+    bt_operand_b_sel_cg  bt_operand_b_sel_cg_h ;
+  `endif  // BRANCH_TARGET_ALU_ENABLED
+  
   alu_op_a_mux_sel_cg  alu_op_a_mux_sel_cg_h ;
   alu_op_b_mux_sel_cg  alu_op_b_mux_sel_cg_h ;
   imm_operand_b_sel_cg imm_operand_b_sel_cg_h;
@@ -1955,8 +1964,12 @@ module ibex_decoder #(
     fpu_cg_h               = new();     // Instance of a fpu covergroup
     opcode_cg_h            = new();     // Instance of a opcode covergroup
     opcode_alu_cg_h        = new();     // Instance of a opcode_alu covergroup
-    bt_operand_a_sel_cg_h  = new();     // Instance of a bt_a_mux_sel_o covergroup
-    bt_operand_b_sel_cg_h  = new();     // Instance of a bt_b_mux_sel_o covergroup
+    
+    `ifdef BRANCH_TARGET_ALU_ENABLED
+      bt_operand_a_sel_cg_h  = new();     // Instance of a bt_a_mux_sel_o covergroup
+      bt_operand_b_sel_cg_h  = new();     // Instance of a bt_b_mux_sel_o covergroup
+    `endif  // BRANCH_TARGET_ALU_ENABLED
+    
     alu_op_a_mux_sel_cg_h  = new();     // Instance of a alu_op_a_mux_sel_o covergroup
     alu_op_b_mux_sel_cg_h  = new();     // Instance of a alu_op_b_mux_sel_o covergroup
     imm_operand_b_sel_cg_h = new();     // Instance of a imm_b_mux_sel_o covergroup

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1885,7 +1885,6 @@ module ibex_decoder #(
   // IMM_B_J,        (Immediate b for jump)
   // IMM_B_INCR_PC,  (Immediate b for PC increment)
   // IMM_B_INCR_ADDR (immediate b for adder)
-
   covergroup bt_operand_b_sel_cg()@(bt_b_mux_sel_o);
     BT_OPERAND_B_SEL: coverpoint bt_b_mux_sel_o;
   endgroup : bt_operand_b_sel_cg
@@ -1897,13 +1896,17 @@ module ibex_decoder #(
   fpu_cg        fpu_cg_h       ;
   opcode_cg     opcode_cg_h    ;
   opcode_alu_cg opcode_alu_cg_h;
+  bt_operand_a_sel_cg bt_operand_a_sel_cg_h;
+  bt_operand_b_sel_cg bt_operand_b_sel_cg_h;
 
   initial begin
-    alu_cg_h        = new();     // Instance of a alu covergroup
-    mul_div_cg_h    = new();     // Instance of a mul/div covergroup
-    fpu_cg_h        = new();     // Instance of a fpu covergroup
-    opcode_cg_h     = new();     // Instance of a opcode covergroup
-    opcode_alu_cg_h = new();     // Instance of a opcode_alu covergroup
+    alu_cg_h              = new();     // Instance of a alu covergroup
+    mul_div_cg_h          = new();     // Instance of a mul/div covergroup
+    fpu_cg_h              = new();     // Instance of a fpu covergroup
+    opcode_cg_h           = new();     // Instance of a opcode covergroup
+    opcode_alu_cg_h       = new();     // Instance of a opcode_alu covergroup
+    bt_operand_a_sel_cg_h = new();     // Instance of a bt_a_mux_sel_o covergroup
+    bt_operand_b_sel_cg_h = new();     // Instance of a bt_b_mux_sel_o covergroup
   end
 
   `endif  // AZADI_FC

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1861,6 +1861,19 @@ module ibex_decoder #(
   covergroup opcode_alu_cg()@(opcode_alu);
     OPCODE_ALU_OPERATIONS: coverpoint opcode_alu;
   endgroup : opcode_alu_cg
+
+  /////////////////////////////////////////
+  // Branch target Operand "A" selection //
+  /////////////////////////////////////////
+  
+  // OP_A_REG_A (operand A from register)
+  // OP_A_FWD   (operand A from forward )
+  // OP_A_CURRPC(operand A as current pc)
+  // OP_A_IMM   (operand A as immediate )
+  covergroup bt_operand_a_sel_cg()@(bt_a_mux_sel_o);
+    BT_OPERAND_A_SEL: coverpoint bt_a_mux_sel_o;
+  endgroup : bt_operand_a_sel_cg
+
   
   // Declaration of cover-groups
   alu_cg        alu_cg_h       ;

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1889,6 +1889,10 @@ module ibex_decoder #(
     BT_OPERAND_B_SEL: coverpoint bt_b_mux_sel_o;
   endgroup : bt_operand_b_sel_cg
 
+  covergroup imm_operand_b_sel_cg()@(imm_b_mux_sel_o);
+    IMM_OPERAND_B_SEL: coverpoint imm_b_mux_sel_o;
+  endgroup : imm_operand_b_sel_cg
+
   //////////////////////////////////////////////////
   // Covergroup for ALU operand "A" mux selection //
   //////////////////////////////////////////////////
@@ -1912,26 +1916,28 @@ module ibex_decoder #(
   endgroup : alu_op_b_mux_sel_cg
   
   // Declaration of cover-groups
-  alu_cg              alu_cg_h             ;
-  mul_div_cg          mul_div_cg_h         ;
-  fpu_cg              fpu_cg_h             ;
-  opcode_cg           opcode_cg_h          ;
-  opcode_alu_cg       opcode_alu_cg_h      ;
-  bt_operand_a_sel_cg bt_operand_a_sel_cg_h;
-  bt_operand_b_sel_cg bt_operand_b_sel_cg_h;
-  alu_op_a_mux_sel_cg alu_op_a_mux_sel_cg_h;
-  alu_op_b_mux_sel_cg alu_op_b_mux_sel_cg_h;
+  alu_cg               alu_cg_h              ;
+  mul_div_cg           mul_div_cg_h          ;
+  fpu_cg               fpu_cg_h              ;
+  opcode_cg            opcode_cg_h           ;
+  opcode_alu_cg        opcode_alu_cg_h       ;
+  bt_operand_a_sel_cg  bt_operand_a_sel_cg_h ;
+  bt_operand_b_sel_cg  bt_operand_b_sel_cg_h ;
+  alu_op_a_mux_sel_cg  alu_op_a_mux_sel_cg_h ;
+  alu_op_b_mux_sel_cg  alu_op_b_mux_sel_cg_h ;
+  imm_operand_b_sel_cg imm_operand_b_sel_cg_h;
 
   initial begin
-    alu_cg_h              = new();     // Instance of a alu covergroup
-    mul_div_cg_h          = new();     // Instance of a mul/div covergroup
-    fpu_cg_h              = new();     // Instance of a fpu covergroup
-    opcode_cg_h           = new();     // Instance of a opcode covergroup
-    opcode_alu_cg_h       = new();     // Instance of a opcode_alu covergroup
-    bt_operand_a_sel_cg_h = new();     // Instance of a bt_a_mux_sel_o covergroup
-    bt_operand_b_sel_cg_h = new();     // Instance of a bt_b_mux_sel_o covergroup
-    alu_op_a_mux_sel_cg_h = new();     // Instance of a alu_op_a_mux_sel_o covergroup
-    alu_op_b_mux_sel_cg_h = new();     // Instance of a alu_op_b_mux_sel_o covergroup
+    alu_cg_h               = new();     // Instance of a alu covergroup
+    mul_div_cg_h           = new();     // Instance of a mul/div covergroup
+    fpu_cg_h               = new();     // Instance of a fpu covergroup
+    opcode_cg_h            = new();     // Instance of a opcode covergroup
+    opcode_alu_cg_h        = new();     // Instance of a opcode_alu covergroup
+    bt_operand_a_sel_cg_h  = new();     // Instance of a bt_a_mux_sel_o covergroup
+    bt_operand_b_sel_cg_h  = new();     // Instance of a bt_b_mux_sel_o covergroup
+    alu_op_a_mux_sel_cg_h  = new();     // Instance of a alu_op_a_mux_sel_o covergroup
+    alu_op_b_mux_sel_cg_h  = new();     // Instance of a alu_op_b_mux_sel_o covergroup
+    imm_operand_b_sel_cg_h = new();     // Instance of a imm_b_mux_sel_o covergroup
   end
 
   `endif  // AZADI_FC

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1788,9 +1788,9 @@ module ibex_decoder #(
   `ASSERT(IbexRegImmAluOpKnown, (opcode == OPCODE_OP_IMM) |->
       !$isunknown(instr[14:12]))
 
-  ////////////////////////
-  //Functional coverages//
-  ////////////////////////
+  ////////////////////////////
+  //  Functional coverages  //
+  ////////////////////////////
   
   `ifdef AZADI_FC
   // Covergroup to capture ALU operations 
@@ -1834,20 +1834,49 @@ module ibex_decoder #(
   covergroup opcode_cg()@(opcode);
     OPCODE_OPERATIONS: coverpoint opcode;
   endgroup : opcode_cg
+
+  //////////////////////////////////////////////////////////////////////////////////////
+  // Added covergroup to capture coverage for typedef opcode_alu present in ibex_pkg  //
+  ////////////////////////////////////////////////////////////////////////////////////
+  // OPCODE_JAL (Jump and Link)
+  // OPCODE_JALR (Jump and Link Register)
+  // OPCODE_BRANCH (Branch)
+  // OPCODE_STORE (Store)
+  // OPCODE_LOAD (Load)
+  // OPCODE_LUI (Load Upper Immediate)
+  // OPCODE_AUIPC (Add Upper Immediate to PC)
+  // OPCODE_OP_IMM (Register-Immediate ALU Operations)
+  // OPCODE_OP (Register-Register ALU operation)
+  // OPCODE_MISC_MEM ( Special)
+  // OPCODE_SYSTEM   (Special)
+  // Floating point 
+  // OPCODE_STORE_FP (Store fp)
+  // OPCODE_LOAD_FP (Load fp)
+  // OPCODE_MADD_FP,  // FMADD.S, FMADD.D
+  // OPCODE_MSUB_FP,  // FMSUB.S, FMSUB.D
+  // OPCODE_NMSUB_FP, // FNMSUB.S, FNMSUB.//D
+  // OPCODE_NMADD_FP: begin //FNMADD.S, FN//MAD
+  // OPCODE_OP_FP
+  // OPCODE_OP_FP
+  covergroup opcode_alu_cg()@(opcode_alu);
+    OPCODE_ALU_OPERATIONS: coverpoint opcode_alu;
+  endgroup : opcode_alu_cg
   
   // Declaration of cover-groups
-  alu_cg     alu_cg_h    ;
-  mul_div_cg mul_div_cg_h;
-  fpu_cg     fpu_cg_h    ;
-  opcode_cg  opcode_cg_h ;
+  alu_cg        alu_cg_h       ;
+  mul_div_cg    mul_div_cg_h   ;
+  fpu_cg        fpu_cg_h       ;
+  opcode_cg     opcode_cg_h    ;
+  opcode_alu_cg opcode_alu_cg_h;
 
   initial begin
-    alu_cg_h     = new();     // Instance of a alu covergroup
-    mul_div_cg_h = new();     // Instance of a mul/div covergroup
-    fpu_cg_h     = new();     // Instance of a fpu covergroup  
-    opcode_cg_h  = new();     // Instance of a opcode covergroup
+    alu_cg_h        = new();     // Instance of a alu covergroup
+    mul_div_cg_h    = new();     // Instance of a mul/div covergroup
+    fpu_cg_h        = new();     // Instance of a fpu covergroup
+    opcode_cg_h     = new();     // Instance of a opcode covergroup
+    opcode_alu_cg_h = new();     // Instance of a opcode_alu covergroup
   end
-  
+
   `endif  // AZADI_FC
 
 endmodule // controller

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1795,17 +1795,19 @@ module ibex_decoder #(
   `ifdef AZADI_FC
   // Covergroup to capture ALU operations 
   covergroup alu_cg ()@(alu_operator_o); 
-    ALU_OPERATIONS: coverpoint alu_operator_o{
+    `ifdef BIT_MANIPULATION_ENABLED
+      ALU_OPERATIONS: coverpoint alu_operator_o;
+    `else
+      ALU_OPERATIONS: coverpoint alu_operator_o{
       // Ignore bins for bit manipulation extension
-      `ifndef BIT_MANIPULATION_ENABLED
-        ignore_bins ignore_vals = {ALU_XNOR, ALU_ORN, ALU_ANDN, ALU_SRO, ALU_SLO, ALU_ROR, ALU_ROL, ALU_GREV,
-          ALU_GORC, ALU_SHFL, ALU_UNSHFL, ALU_MIN, ALU_MINU, ALU_MAX, ALU_MAXU, ALU_PACK,
-          ALU_PACKU, ALU_PACKH, ALU_SEXTB, ALU_SEXTH, ALU_CLZ, ALU_CTZ, ALU_PCNT, ALU_CMOV,
-          ALU_CMIX, ALU_FSL, ALU_FSR, ALU_SBSET, ALU_SBCLR, ALU_SBINV, ALU_SBEXT, ALU_BEXT,
-          ALU_BDEP, ALU_BFP, ALU_CLMUL, ALU_CLMULR, ALU_CLMULH, ALU_CRC32_B, ALU_CRC32C_B,
-          ALU_CRC32_H, ALU_CRC32C_H, ALU_CRC32_W, ALU_CRC32C_W};
+      ignore_bins ignore_vals = {ALU_XNOR, ALU_ORN, ALU_ANDN, ALU_SRO, ALU_SLO, ALU_ROR, ALU_ROL, ALU_GREV,
+        ALU_GORC, ALU_SHFL, ALU_UNSHFL, ALU_MIN, ALU_MINU, ALU_MAX, ALU_MAXU, ALU_PACK,
+        ALU_PACKU, ALU_PACKH, ALU_SEXTB, ALU_SEXTH, ALU_CLZ, ALU_CTZ, ALU_PCNT, ALU_CMOV,
+        ALU_CMIX, ALU_FSL, ALU_FSR, ALU_SBSET, ALU_SBCLR, ALU_SBINV, ALU_SBEXT, ALU_BEXT,
+        ALU_BDEP, ALU_BFP, ALU_CLMUL, ALU_CLMULR, ALU_CLMULH, ALU_CRC32_B, ALU_CRC32C_B,
+        ALU_CRC32_H, ALU_CRC32C_H, ALU_CRC32_W, ALU_CRC32C_W};
       }
-      `endif
+    `endif
   endgroup : alu_cg
 
   // Covergroup to capture Multiplier/divider operations


### PR DESCRIPTION
Added cover groups to capture the functional coverage. I have implemented the cover groups in the decoder of AZADI core.
Captured coverage for
- ALU operations
- Multiplier/divider operations
- Floating-point operations
- Branch target ALU operations
- Operand selection
- Bit manipulation

Each cover group captures functional coverage of multiple instructions. The details are present with each cover groups in the decoder.
**Sampling** the test coverage in the tb_top.

There are cover groups present for bit manipulation and Branch target ALU operations. Currently, these features are disabled in the core. So to capture the coverage of related cover groups you must add defines **BRANCH_TARGET_ALU_ENABLED** and  **BIT_MANIPULATION_ENABLED** for branch target and bit manipulation respectively in the file [at path azadi-verify/env/core/vendor/core_ibex/yaml/rtl_simulation.yaml](https://github.com/merledu/azadi-verify/blob/main/env/core/vendor/core_ibex/yaml/rtl_simulation.yaml)
As we are simulating on Cadence Xcelium for we need the define under tool: xlm (Refer the +define+AZADI_FC that is already present in the same rtl_simulation.yaml file)