### PR TITLE
Added more covergroups for capturing functioanal coverage

### DIFF
--- a/hw/vendor/lowrisc_ibex/rtl/ibex_cs_registers.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_cs_registers.sv
@@ -1561,16 +1561,26 @@ module ibex_cs_registers #(
     M_STATUS_MPRV:  coverpoint  mstatus_d.mprv;
     M_STATUS_TW  :  coverpoint  mstatus_d.tw;  
   endgroup : m_status_reg_cg
+
+  // Covergroup for CPU control register field
+  covergroup cpu_ctrl_cg ()@(cpuctrl_q); 
+    CPU_CTRL_DUMMY_INSTR_MASK :  coverpoint cpuctrl_q.dummy_instr_mask;
+    CPU_CTRL_DUMMY_INSTR_EN   :  coverpoint cpuctrl_q.dummy_instr_en;
+    CPU_CTRL_DATA_IND_TIMING  :  coverpoint cpuctrl_q.data_ind_timing;
+    CPU_CTRL_ICACHE_EN        :  coverpoint cpuctrl_q.icache_enable;
+  endgroup : cpu_ctrl_cg
   
   // Declaration of cover-groups
   dcsr_xdebugver_cg   dcsr_xdebugver_cg_h  ;
   dcsr_d_xdebugver_cg dcsr_d_xdebugver_cg_h;
   m_status_reg_cg     m_status_reg_cg_h    ;
+  cpu_ctrl_cg         cpu_ctrl_cg_h        ;
 
   initial begin
     dcsr_xdebugver_cg_h   = new();       // Instance of a dcsr_xdebugver_cg covergroup
     dcsr_d_xdebugver_cg_h = new();       // Instance of a dcsr_d_xdebugver_cg covergroup
     m_status_reg_cg_h     = new();       // Instance of a machine mode status register covergroup
+    cpu_ctrl_cg_h         = new();       // Instance of a cpu control covergroup
   end
 
   `endif  // AZADI_FC

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_cs_registers.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_cs_registers.sv
@@ -1531,19 +1531,48 @@ module ibex_cs_registers #(
   
   // Covergroup to capture dcsr_d
   covergroup dcsr_d_xdebugver_cg ()@(dcsr_d); 
-    DCSR_D_XDEBUGER : coverpoint dcsr_d;
+    DCSR_D_XDEBUGER_XDEBUGVER:  coverpoint dcsr_d.xdebugver;
+    DCSR_D_XDEBUGER_ZERO2    :  coverpoint dcsr_d.zero2;
+    DCSR_D_XDEBUGER_EBREAKM  :  coverpoint dcsr_d.ebreakm;
+    DCSR_D_XDEBUGER_ZERO1    :  coverpoint dcsr_d.zero1;
+    DCSR_D_XDEBUGER_EBREAKS  :  coverpoint dcsr_d.ebreaks;
+    DCSR_D_XDEBUGER_EBREAKU  :  coverpoint dcsr_d.ebreaku;
+    DCSR_D_XDEBUGER_STEPIE   :  coverpoint dcsr_d.stepie;
+    DCSR_D_XDEBUGER_STOPCOUNT:  coverpoint dcsr_d.stopcount;
+    DCSR_D_XDEBUGER_STOPTIME :  coverpoint dcsr_d.stoptime;
+    DCSR_D_XDEBUGER_CAUSE    :  coverpoint dcsr_d.cause;
+    DCSR_D_XDEBUGER_ZERO0    :  coverpoint dcsr_d.zero0;
+    DCSR_D_XDEBUGER_MPRVEN   :  coverpoint dcsr_d.mprven;
+    DCSR_D_XDEBUGER_NMIP     :  coverpoint dcsr_d.nmip;
+    DCSR_D_XDEBUGER_STEP     :  coverpoint dcsr_d.step;
+    DCSR_D_XDEBUGER_PRV      :  coverpoint dcsr_d.prv;
   endgroup : dcsr_d_xdebugver_cg
+  
+  // Covergroup for machine status register (m status register)
+  // mie;   // Machine interupt enable
+  // mpie;  // Machine pending interupt enable
+  // mpp;   // Machine previous privilege mode
+  // mprv;  // Memory privilege for memory protection
+  // tw
+  covergroup m_status_reg_cg ()@(mstatus_d); 
+    M_STATUS_MIE :  coverpoint  mstatus_d.mie;
+    M_STATUS_MPIE:  coverpoint  mstatus_d.mpie;
+    M_STATUS_MPP :  coverpoint  mstatus_d.mpp; 
+    M_STATUS_MPRV:  coverpoint  mstatus_d.mprv;
+    M_STATUS_TW  :  coverpoint  mstatus_d.tw;  
+  endgroup : m_status_reg_cg
   
   // Declaration of cover-groups
   dcsr_xdebugver_cg   dcsr_xdebugver_cg_h  ;
   dcsr_d_xdebugver_cg dcsr_d_xdebugver_cg_h;
+  m_status_reg_cg     m_status_reg_cg_h    ;
 
   initial begin
     dcsr_xdebugver_cg_h   = new();       // Instance of a dcsr_xdebugver_cg covergroup
     dcsr_d_xdebugver_cg_h = new();       // Instance of a dcsr_d_xdebugver_cg covergroup
+    m_status_reg_cg_h     = new();       // Instance of a machine mode status register covergroup
   end
 
   `endif  // AZADI_FC
-
 
 endmodule

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_cs_registers.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_cs_registers.sv
@@ -1521,7 +1521,7 @@ module ibex_cs_registers #(
   
   `ifdef AZADI_FC
 
-  // Covergroup to capture Constants for the dcsr.xdebugver fields
+  // Covergroup to capture constants for the dcsr.xdebugver fields
   // XDEBUGVER_NO     ( 4'd0,) no external debug support
   // XDEBUGVER_STD    ( 4'd4,) external debug according to RISC-V debug spec
   // XDEBUGVER_NONSTD ( 4'd15) debug not conforming to RISC-V debug spec
@@ -1529,11 +1529,18 @@ module ibex_cs_registers #(
     DCSR_XDEBUGER : coverpoint dcsr_d.xdebugver;
   endgroup : dcsr_xdebugver_cg
   
+  // Covergroup to capture dcsr_d
+  covergroup dcsr_d_xdebugver_cg ()@(dcsr_d); 
+    DCSR_D_XDEBUGER : coverpoint dcsr_d;
+  endgroup : dcsr_d_xdebugver_cg
+  
   // Declaration of cover-groups
-  dcsr_xdebugver_cg dcsr_xdebugver_cg_h;
+  dcsr_xdebugver_cg   dcsr_xdebugver_cg_h  ;
+  dcsr_d_xdebugver_cg dcsr_d_xdebugver_cg_h;
 
   initial begin
-    dcsr_xdebugver_cg_h = new();       // Instance of a dcsr_xdebugver_cg covergroup
+    dcsr_xdebugver_cg_h   = new();       // Instance of a dcsr_xdebugver_cg covergroup
+    dcsr_d_xdebugver_cg_h = new();       // Instance of a dcsr_d_xdebugver_cg covergroup
   end
 
   `endif  // AZADI_FC

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_cs_registers.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_cs_registers.sv
@@ -1515,4 +1515,28 @@ module ibex_cs_registers #(
 
   `ASSERT(IbexCsrOpEnRequiresAccess, csr_op_en_i |-> csr_access_i)
 
+  ////////////////////////////
+  //  Functional coverages  //
+  ////////////////////////////
+  
+  `ifdef AZADI_FC
+
+  // Covergroup to capture Constants for the dcsr.xdebugver fields
+  // XDEBUGVER_NO     ( 4'd0,) no external debug support
+  // XDEBUGVER_STD    ( 4'd4,) external debug according to RISC-V debug spec
+  // XDEBUGVER_NONSTD ( 4'd15) debug not conforming to RISC-V debug spec
+  covergroup dcsr_xdebugver_cg ()@(dcsr_d.xdebugver); 
+    DCSR_XDEBUGER : coverpoint dcsr_d.xdebugver;
+  endgroup : dcsr_xdebugver_cg
+  
+  // Declaration of cover-groups
+  dcsr_xdebugver_cg dcsr_xdebugver_cg_h;
+
+  initial begin
+    dcsr_xdebugver_cg_h = new();       // Instance of a dcsr_xdebugver_cg covergroup
+  end
+
+  `endif  // AZADI_FC
+
+
 endmodule

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_decoder.sv
@@ -1951,6 +1951,13 @@ module ibex_decoder #(
   covergroup csr_operations_cg()@(csr_op_o);
     CSR_OPERATIONS: coverpoint csr_op_o;
   endgroup : csr_operations_cg
+
+  /////////////////////////////////////////////////
+  // Covergroup for Regfile write data selection //
+  /////////////////////////////////////////////////
+  covergroup rf_wd_sel_cg()@(rf_wdata_sel_o);
+    RF_WD_SEL: coverpoint rf_wdata_sel_o;
+  endgroup : rf_wd_sel_cg
   
   // Declaration of cover-groups
   alu_cg               alu_cg_h              ;
@@ -1959,6 +1966,7 @@ module ibex_decoder #(
   opcode_cg            opcode_cg_h           ;
   opcode_alu_cg        opcode_alu_cg_h       ;
   csr_operations_cg    csr_operations_cg_h   ;
+  rf_wd_sel_cg         rf_wd_sel_cg_h        ;
   
   `ifdef BRANCH_TARGET_ALU_ENABLED
     bt_operand_a_sel_cg  bt_operand_a_sel_cg_h ;
@@ -1989,6 +1997,7 @@ module ibex_decoder #(
     alu_op_a_mux_sel_cg_h  = new();       // Instance of a alu_op_a_mux_sel_o covergroup
     alu_op_b_mux_sel_cg_h  = new();       // Instance of a alu_op_b_mux_sel_o covergroup
     imm_operand_b_sel_cg_h = new();       // Instance of a imm_b_mux_sel_o covergroup
+    rf_wd_sel_cg_h         = new();       // Instance of a rf_wd_sel_cg covergroup
     
     `ifdef BIT_MANIPULATION_ENABLED
       bit_manipulation_cg_h  = new();     // Instance of a RV32B covergroup

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_id_stage.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_id_stage.sv
@@ -1220,15 +1220,22 @@ module ibex_id_stage #(
     EXCEPTION_PC_MUX_SEL: coverpoint exc_pc_mux_o;
   endgroup : exc_pc_mux_cg
 
+  // Covergroup for interrupt signals
+  covergroup irqs_cg ()@(irqs_i); 
+    INTERRUPT_SIGNAL : coverpoint irqs_i;
+  endgroup : irqs_cg
+
   // Declaration of cover-groups
   priv_mode_cg  priv_mode_cg_h ;
   pc_mux_cg     pc_mux_cg_h    ;
   exc_pc_mux_cg exc_pc_mux_cg_h;
+  irqs_cg       irqs_cg_h      ;
   
   initial begin
     priv_mode_cg_h  = new();       // Instance of a privileged mode covergroup
     pc_mux_cg_h     = new();       // Instance of a pc mux selection covergroup
-    exc_pc_mux_cg_h = new();       // Instance of a Exception pc mux selection covergroup
+    exc_pc_mux_cg_h = new();       // Instance of a exception pc mux selection covergroup
+    irqs_cg_h       = new();       // Instance of a interrupt signals covergroup
   end
 
   `endif  // AZADI_FC

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_id_stage.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_id_stage.sv
@@ -1225,17 +1225,39 @@ module ibex_id_stage #(
     INTERRUPT_SIGNAL : coverpoint irqs_i;
   endgroup : irqs_cg
 
+  // Covergroup for exception causes
+
+  // EXC_CAUSE_IRQ_SOFTWARE_M    
+  // EXC_CAUSE_IRQ_TIMER_M       
+  // EXC_CAUSE_IRQ_EXTERNAL_M    
+  // EXC_CAUSE_IRQ_FAST_0     
+  // EXC_CAUSE_IRQ_FAST_14    
+  // EXC_CAUSE_IRQ_NM            
+  // EXC_CAUSE_INSN_ADDR_MISA    
+  // EXC_CAUSE_INSTR_ACCESS_FAULT
+  // EXC_CAUSE_ILLEGAL_INSN      
+  // EXC_CAUSE_BREAKPOINT        
+  // EXC_CAUSE_LOAD_ACCESS_FAULT 
+  // EXC_CAUSE_STORE_ACCESS_FAULT
+  // EXC_CAUSE_ECALL_UMODE       
+  // EXC_CAUSE_ECALL_MMODE       
+  covergroup exc_cause_cg ()@(exc_cause_o); 
+    EXCEPTION_CAUSES : coverpoint exc_cause_o;
+  endgroup : exc_cause_cg
+
   // Declaration of cover-groups
   priv_mode_cg  priv_mode_cg_h ;
   pc_mux_cg     pc_mux_cg_h    ;
   exc_pc_mux_cg exc_pc_mux_cg_h;
   irqs_cg       irqs_cg_h      ;
+  exc_cause_cg  exc_cause_cg_h ;
   
   initial begin
     priv_mode_cg_h  = new();       // Instance of a privileged mode covergroup
     pc_mux_cg_h     = new();       // Instance of a pc mux selection covergroup
     exc_pc_mux_cg_h = new();       // Instance of a exception pc mux selection covergroup
     irqs_cg_h       = new();       // Instance of a interrupt signals covergroup
+    exc_cause_cg_h  = new();       // Instance of a excepton causes
   end
 
   `endif  // AZADI_FC

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_id_stage.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_id_stage.sv
@@ -1204,4 +1204,18 @@ module ibex_id_stage #(
   `ASSERT(IbexMisalignedMemoryAccess, !lsu_addr_incr_req_i)
   `endif
 
+  `ifdef AZADI_FC
+  // Covergroup to capture of Privileged modes
+  covergroup priv_mode_cg ()@(priv_mode_i); 
+    PRIVILEGED_MODE: coverpoint priv_mode_i;
+  endgroup : priv_mode_cg
+  `endif  // AZADI_FC
+
+  // Declaration of cover-groups
+  priv_mode_cg               priv_mode_cg_h;
+
+  initial begin
+    priv_mode_cg_h  = new();       // Instance of a privileged mode covergroup
+  end
+
 endmodule

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_id_stage.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_id_stage.sv
@@ -1209,19 +1209,26 @@ module ibex_id_stage #(
   covergroup priv_mode_cg ()@(priv_mode_i); 
     PRIVILEGED_MODE: coverpoint priv_mode_i;
   endgroup : priv_mode_cg
-  
+
   // Covergroup for PC mux selection
   covergroup pc_mux_cg ()@(pc_mux_o); 
     PC_MUX_SEL: coverpoint pc_mux_o;
   endgroup : pc_mux_cg
 
-  // Declaration of cover-groups
-  priv_mode_cg priv_mode_cg_h;
-  pc_mux_cg    pc_mux_cg_h;               
+  // Covergroup for Exception PC mux selection
+  covergroup exc_pc_mux_cg ()@(exc_pc_mux_o); 
+    EXCEPTION_PC_MUX_SEL: coverpoint exc_pc_mux_o;
+  endgroup : exc_pc_mux_cg
 
+  // Declaration of cover-groups
+  priv_mode_cg  priv_mode_cg_h ;
+  pc_mux_cg     pc_mux_cg_h    ;
+  exc_pc_mux_cg exc_pc_mux_cg_h;
+  
   initial begin
-    priv_mode_cg_h = new();       // Instance of a privileged mode covergroup
-    pc_mux_cg_h    = new();       // Instance of a pc mux selection covergroup
+    priv_mode_cg_h  = new();       // Instance of a privileged mode covergroup
+    pc_mux_cg_h     = new();       // Instance of a pc mux selection covergroup
+    exc_pc_mux_cg_h = new();       // Instance of a Exception pc mux selection covergroup
   end
 
   `endif  // AZADI_FC

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_id_stage.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_id_stage.sv
@@ -1209,13 +1209,21 @@ module ibex_id_stage #(
   covergroup priv_mode_cg ()@(priv_mode_i); 
     PRIVILEGED_MODE: coverpoint priv_mode_i;
   endgroup : priv_mode_cg
-  `endif  // AZADI_FC
+  
+  // Covergroup for PC mux selection
+  covergroup pc_mux_cg ()@(pc_mux_o); 
+    PC_MUX_SEL: coverpoint pc_mux_o;
+  endgroup : pc_mux_cg
 
   // Declaration of cover-groups
-  priv_mode_cg               priv_mode_cg_h;
+  priv_mode_cg priv_mode_cg_h;
+  pc_mux_cg    pc_mux_cg_h;               
 
   initial begin
-    priv_mode_cg_h  = new();       // Instance of a privileged mode covergroup
+    priv_mode_cg_h = new();       // Instance of a privileged mode covergroup
+    pc_mux_cg_h    = new();       // Instance of a pc mux selection covergroup
   end
+
+  `endif  // AZADI_FC
 
 endmodule

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_wb_stage.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_wb_stage.sv
@@ -254,4 +254,21 @@ module ibex_wb_stage #(
 `DV_FCOV_SIGNAL_GEN_IF(logic, wb_valid, g_writeback_stage.wb_valid_q, WritebackStage)
 
   `ASSERT(RFWriteFromOneSourceOnly, $onehot0(rf_wdata_wb_mux_we))
+
+  `ifdef AZADI_FC
+
+  // Covergroup for type of instruction present in writeback stage
+  covergroup wb_instr_type_cg ()@(instr_type_wb_i); 
+    WB_INSTR_TYPE : coverpoint instr_type_wb_i;
+  endgroup : wb_instr_type_cg
+
+  // Declaration of cover-groups
+  wb_instr_type_cg wb_instr_type_cg_h;
+
+  initial begin
+    wb_instr_type_cg_h = new();       // Instance of a covergroup for type of instruction present in writeback stage
+  end
+
+  `endif  // AZADI_FC
+
 endmodule


### PR DESCRIPTION
Implemented functional coverage for following

1) Privileged modes 
2) PC mux selection
3) Regfile write data selection
4) CSR operations
5) DCSR
6) M status register fields
7) CPU control register field
8) Type of instruction present in write back stage
9) Exception PC mux selection
10) Interrupt signals
11) Exception causes